### PR TITLE
Add function that it has been accidentally deleted

### DIFF
--- a/src/dpa_library.c
+++ b/src/dpa_library.c
@@ -610,6 +610,17 @@ void DPA_SendDataByte(uint8_t dataByte) {
 }
 
 /**
+ * Transfers received byte from UART to DPA support library
+ * @param rxByte Received byte
+ */
+void DPA_ReceiveUartByte(uint8_t rxByte) {
+	// Write received byte to Rx FiFo
+	dpaUartIfControl.rxBuff[dpaUartIfControl.rxBuffInPtr++] = rxByte;
+	// This makes 16 bytes circle buffer
+	dpaUartIfControl.rxBuffInPtr &= 0x0F;
+}
+
+/**
  * Calculate the CRC8 value of a data set
  * @param inData One byte of data to compute CRC
  * @param seed The starting value of the CRC


### PR DESCRIPTION
Add function for UART communication that it has been accidentally deleted in commit 158ad2fbac37da2d0accff0fb408b2ee9f955503.

Signed-off-by: Roman3349 ondracek.roman@centrum.cz
