### PR TITLE
Fix a deselecting the TR module after the MCU send packet to the TR module via the SPI bus

### DIFF
--- a/examples/Blink/Blink/Blink.ino
+++ b/examples/Blink/Blink/Blink.ino
@@ -109,7 +109,10 @@ typedef struct {
     volatile uint16_t swTimer;
     volatile bool swTimerAck;
     volatile uint8_t ticks;
-
+#if defined(__SPI_INTERFACE__) && defined(TR7xD)
+    // SPI
+    bool TRmoduleSelected;
+#endif
     // DPA
     volatile uint16_t dpaTimeoutCnt;
     uint16_t dpaStep;
@@ -344,6 +347,9 @@ uint32_t usTimerCallbackPic32(uint32_t currentTime) {
  * DPA SPI deselect module
  */
 void DPA_DeselectTRmodule() {
+#if defined(TR7xD)
+    app_vars.TRmoduleSelected = false;
+#endif
     pinMode(iqrfSs, OUTPUT);
     digitalWrite(iqrfSs, HIGH);
 }
@@ -354,13 +360,21 @@ void DPA_DeselectTRmodule() {
  * @return Received byte
  */
 uint8_t DPA_SendSpiByte(uint8_t txByte) {
+#if defined(TR7xD)
+    if (!app_vars.TRmoduleSelected) {
+        app_vars.TRmoduleSelected = true;
+        digitalWrite(iqrfSs, LOW);
+        delayMicroseconds(15);
+    }
+#else
     digitalWrite(iqrfSs, LOW);
     delayMicroseconds(15);
+#endif
     SPI.beginTransaction(SPISettings(250000, MSBFIRST, SPI_MODE0));
     uint8_t rxByte = SPI.transfer(txByte);
     SPI.endTransaction();
     delayMicroseconds(15);
-    digitalWrite(iqrfSs, HIGH);
+    DPA_DeselectTRmodule();
     return rxByte;
 }
 #elif defined(__UART_INTERFACE__)


### PR DESCRIPTION
Fix a deselecting the TR module after the MCU send packet to the TR module via the SPI bus.

Signed-off-by: Roman3349 <ondracek.roman@centrum.cz>