### PR TITLE
Fix compilation error on Arduino Due and chipKIT development boards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - env: PLATFORMIO_CI_SRC=examples/MQTT/MQTT/MQTT.ino
 install:
     - pip install -U platformio
-    - platformio lib -g install MsTimer2 TimerOne DueTimer PubSubClient
+    - platformio lib -g install TimerOne DueTimer PubSubClient
     # Tmp fix for Microchip gcc-pic32
     - sudo apt-get install lib32z1 lib32ncurses5 lib32bz2-1.0
 script:

--- a/examples/Blink/platformio.ini
+++ b/examples/Blink/platformio.ini
@@ -82,6 +82,14 @@ framework = arduino
 lib_deps = TimerOne, IQRF DPA
 lib_ignore = DueTimer
 
+;[env:teensy36]
+;platform = teensy
+;board = teensy36
+;framework = arduino
+;lib_deps = TimerOne, IQRF DPA
+;lib_ignore = DueTimer
+;build_flags = -D USB_SERIAL_HID
+
 [env:uno_pic32]
 platform = microchippic32
 framework = arduino

--- a/examples/MQTT/platformio.ini
+++ b/examples/MQTT/platformio.ini
@@ -19,66 +19,88 @@
 [platformio]
 src_dir = MQTT
 
-[env:uno]
-platform = atmelavr
-framework = arduino
-board = uno
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
-lib_ignore = DueTimer
-
 [env:due]
 platform = atmelsam
 framework = arduino
 board = due
 lib_deps = DueTimer, IQRF DPA, PubSubClient
-lib_ignore = MsTimer2, TimerOne
+lib_ignore = TimerOne
+
+[env:uno]
+platform = atmelavr
+framework = arduino
+board = uno
+lib_deps = TimerOne, IQRF DPA, PubSubClient
+lib_ignore = DueTimer
 
 [env:leonardo]
 platform = atmelavr
 framework = arduino
 board = leonardo
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
+lib_deps = TimerOne, IQRF DPA, PubSubClient
 lib_ignore = DueTimer
 
 [env:diecimilaatmega168]
 platform = atmelavr
 framework = arduino
 board = diecimilaatmega168
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
+lib_deps = TimerOne, IQRF DPA, PubSubClient
 lib_ignore = DueTimer
 
 [env:megaatmega1280]
 platform = atmelavr
 framework = arduino
 board = megaatmega1280
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
+lib_deps = TimerOne, IQRF DPA, PubSubClient
 lib_ignore = DueTimer
 
 [env:megaatmega2560]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
+lib_deps = TimerOne, IQRF DPA, PubSubClient
 lib_ignore = DueTimer
+
+[env:teensy20]
+platform = teensy
+board = teensy20
+framework = arduino
+lib_deps = TimerOne, IQRF DPA, PubSubClient
+lib_ignore = DueTimer
+
+[env:teensy20pp]
+platform = teensy
+board = teensy20pp
+framework = arduino
+lib_deps = TimerOne, IQRF DPA, PubSubClient
+lib_ignore = DueTimer
+
+[env:teensy31]
+platform = teensy
+board = teensy31
+framework = arduino
+lib_deps = TimerOne, IQRF DPA, PubSubClient
+lib_ignore = DueTimer
+
+;[env:teensy36]
+;platform = teensy
+;board = teensy36
+;framework = arduino
+;lib_deps = TimerOne, IQRF DPA, PubSubClient
+;lib_ignore = DueTimer
+;build_flags = -D USB_SERIAL_HID
 
 [env:uno_pic32]
 platform = microchippic32
 framework = arduino
 board = uno_pic32
 lib_deps = IQRF DPA, PubSubClient
-lib_ignore = MsTimer2, TimerOne, DueTimer
+lib_ignore = TimerOne, DueTimer
 
 [env:chipkit_uc32]
 platform = microchippic32
 framework = arduino
 board = chipkit_uc32
 lib_deps = IQRF DPA, PubSubClient
-lib_ignore = MsTimer2, TimerOne, DueTimer
+lib_ignore = TimerOne, DueTimer
 
-[env:teensy36]
-platform = teensy
-framework = arduino
-board = teensy36
-lib_deps = MsTimer2, TimerOne, IQRF DPA, PubSubClient
-lib_ignore = DueTimer
-build_flags = -D USB_SERIAL_HID

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,53 +20,83 @@
 platform = atmelsam
 framework = arduino
 board = due
+lib_deps = DueTimer
+lib_ignore = TimerOne
 
 [env:uno]
 platform = atmelavr
 framework = arduino
 board = uno
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:leonardo]
 platform = atmelavr
 framework = arduino
 board = leonardo
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:diecimilaatmega168]
 platform = atmelavr
 framework = arduino
 board = diecimilaatmega168
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:megaatmega1280]
 platform = atmelavr
 framework = arduino
 board = megaatmega1280
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:megaatmega2560]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:teensy20]
 platform = teensy
-framework = arduino
 board = teensy20
+framework = arduino
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:teensy20pp]
 platform = teensy
-framework = arduino
 board = teensy20pp
+framework = arduino
+lib_deps = TimerOne
+lib_ignore = DueTimer
 
 [env:teensy31]
 platform = teensy
-framework = arduino
 board = teensy31
+framework = arduino
+lib_deps = TimerOne
+lib_ignore = DueTimer
+
+;[env:teensy36]
+;platform = teensy
+;board = teensy36
+;framework = arduino
+;lib_deps = TimerOne
+;lib_ignore = DueTimer
+;build_flags = -D USB_SERIAL_HID
 
 [env:uno_pic32]
 platform = microchippic32
 framework = arduino
 board = uno_pic32
+lib_deps = IQRF DPA
+lib_ignore = TimerOne, DueTimer
 
 [env:chipkit_uc32]
 platform = microchippic32
 framework = arduino
 board = chipkit_uc32
+lib_deps = IQRF DPA
+lib_ignore = TimerOne, DueTimer


### PR DESCRIPTION
File ```platformio.ini``` contains only informations about compilation of examples. Examples have dependencies TimerOne, MsTimer2 and DueTimer (only Arduino Due).

Signed-off-by: Roman3349 <ondracek.roman@centrum.cz>